### PR TITLE
move everything into the macro

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.7.4-otp-20
-erlang 20.3
+elixir 1.10.4
+erlang 22.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.0] - 2020-09-30
+
+### Changed
+* moved all code generation to compile-time due to compiler warnings in Elixir 1.10+
+
+
 ## [0.1.1] - 2020-09-30
 
 ### Changed

--- a/lib/rewire.ex
+++ b/lib/rewire.ex
@@ -24,6 +24,4 @@ defmodule Rewire do
     aliases = Module.get_attribute(__CALLER__.module, :rewire_aliases) || []
     Rewire.Block.rewire_block(rewire_expr, [], aliases, block)
   end
-
-  defdelegate rewire_module(mod, opts \\ []), to: Rewire.Module
 end

--- a/lib/rewire.ex
+++ b/lib/rewire.ex
@@ -10,7 +10,7 @@ defmodule Rewire do
       # Hook to keep track of functions and their aliases.
       @on_definition Rewire.Block
 
-      # Required for importing the `rewire` macro.
+      # Needed for importing the `rewire` macro.
       import Rewire
     end
   end

--- a/lib/rewire/module.ex
+++ b/lib/rewire/module.ex
@@ -26,12 +26,14 @@ defmodule Rewire.Module do
     # Create a copy of the AST with a new module name and replaced dependencies.
     old_mod_name = mod |> Atom.to_string() |> String.trim_leading("Elixir.")
     new_mod_name = Map.fetch!(opts, :new_module_ast) |> module_ast_to_name()
+
     new_ast =
       traverse(
         ast,
         module_name_to_ast(old_mod_name),
         module_name_to_ast(new_mod_name),
-        opts)
+        opts
+      )
 
     # Now evaluate the new module's AST so the file location is correct. (is there a better way?)
     Code.eval_quoted(new_ast, [], file: source_path)
@@ -80,12 +82,14 @@ defmodule Rewire.Module do
       List.starts_with?(full_module_ast, old_module_ast) ->
         # We found a nested module within the module to rewrite,
         # let's rewire that one too since it might contain references to the parent module.
-        {[], acc} # TODO
+        # TODO
+        {[], acc}
 
       List.starts_with?(old_module_ast, full_module_ast) ->
         # We (possibly) found a wrapper module around the module to rewrite,
         # let's look ahead to find the nested module so we can skip the rest.
-        {[], acc} # TODO
+        # TODO
+        {[], acc}
 
       true ->
         # Skip module entirely because it would just be redefined, causing a warning.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Rewire.MixProject do
   def project do
     [
       app: :rewire,
-      version: "0.1.1",
+      version: "0.2.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/rewire_test.exs
+++ b/test/rewire_test.exs
@@ -39,20 +39,20 @@ defmodule RewireTest do
     refute output =~ "warning"
   end
 
-  # @tag :skip
-  # test "creates copy of a nested module" do
-  #   output =
-  #     capture_io(:stderr, fn ->
-  #       original_module = Rewire.ModuleWithNested.Nested.NestedNested
+  @tag :skip
+  test "creates copy of a nested module" do
+    output =
+      capture_io(:stderr, fn ->
+        original_module = Rewire.ModuleWithNested.Nested.NestedNested
 
-  #       rewire Rewire.ModuleWithNested.Nested.NestedNested do
-  #         assert Rewire.ModuleWithNested.Nested.NestedNested != original_module
-  #         assert Rewire.ModuleWithNested.Nested.NestedNested.hello() == original_module.hello()
-  #       end
-  #     end)
+        rewire Rewire.ModuleWithNested.Nested.NestedNested do
+          assert Rewire.ModuleWithNested.Nested.NestedNested != original_module
+          assert Rewire.ModuleWithNested.Nested.NestedNested.hello() == original_module.hello()
+        end
+      end)
 
-  #   refute output =~ "warning"
-  # end
+    refute output =~ "warning"
+  end
 
   test "rewires non-aliased dependency" do
     output =

--- a/test/rewire_test.exs
+++ b/test/rewire_test.exs
@@ -39,20 +39,20 @@ defmodule RewireTest do
     refute output =~ "warning"
   end
 
-  @tag :skip
-  test "creates copy of a nested module" do
-    output =
-      capture_io(:stderr, fn ->
-        original_module = Rewire.ModuleWithNested.Nested.NestedNested
+  # TODO
+  # test "creates copy of a nested module" do
+  #   output =
+  #     capture_io(:stderr, fn ->
+  #       original_module = Rewire.ModuleWithNested.Nested.NestedNested
 
-        rewire Rewire.ModuleWithNested.Nested.NestedNested do
-          assert Rewire.ModuleWithNested.Nested.NestedNested != original_module
-          assert Rewire.ModuleWithNested.Nested.NestedNested.hello() == original_module.hello()
-        end
-      end)
+  #       rewire Rewire.ModuleWithNested.Nested.NestedNested do
+  #         assert Rewire.ModuleWithNested.Nested.NestedNested != original_module
+  #         assert Rewire.ModuleWithNested.Nested.NestedNested.hello() == original_module.hello()
+  #       end
+  #     end)
 
-    refute output =~ "warning"
-  end
+  #   refute output =~ "warning"
+  # end
 
   test "rewires non-aliased dependency" do
     output =

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,22 @@
 ExUnit.start()
 
 Mox.defmock(Rewire.HelloMock, for: Rewire.Hello)
+
+defmodule Assertions do
+  defmodule DidNotRaise, do: defstruct(description: nil)
+
+  defmacro assert_compile_time_raise(expected_message, do: block) do
+    actual_exception =
+      try do
+        Code.eval_quoted(block)
+        %DidNotRaise{}
+      rescue
+        e -> e
+      end
+
+    quote do
+      assert unquote(actual_exception.__struct__) == unquote(CompileError)
+      assert unquote(actual_exception.description) == unquote(expected_message)
+    end
+  end
+end


### PR DESCRIPTION
Starting in Elixir 1.10 the previous approach displayed warnings for the generated modules. By moving everything into the macro, they disappear.