### PR TITLE
Support `use` macro

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.14.0-otp-25
-erlang 25.0
+elixir 1.17
+erlang 26.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17
-erlang 26.0
+elixir 1.14.0-otp-25
+erlang 25.0

--- a/fixtures/macro.ex
+++ b/fixtures/macro.ex
@@ -1,0 +1,22 @@
+defmodule Rewire.Macro do
+  defmacro __using__(_opts) do
+    quote do
+      import Rewire.Hello
+      import Rewire.Goodbye
+    end
+  end
+
+  # defmacro __using__(opts) do
+  #   case opts do
+  #     [] ->
+  #       quote do
+  #         import Rewire.Hello
+  #       end
+
+  #     _ ->
+  #       quote do
+  #         import Rewire.Hello, only: [hello: 0]
+  #       end
+  #   end
+  # end
+end

--- a/fixtures/macro.ex
+++ b/fixtures/macro.ex
@@ -4,12 +4,18 @@ defmodule Rewire.Macro do
       [use_alias: true] ->
         quote do
           alias Rewire.Hello
+          alias Rewire.Macro
         end
 
       _ ->
         quote do
           import Rewire.Hello
+          import Rewire.Macro
         end
     end
+  end
+
+  def good_afternoon do
+    "good afternoon"
   end
 end

--- a/fixtures/macro.ex
+++ b/fixtures/macro.ex
@@ -1,22 +1,22 @@
 defmodule Rewire.Macro do
-  defmacro __using__(_opts) do
-    quote do
-      import Rewire.Hello
-      import Rewire.Goodbye
-    end
-  end
-
-  # defmacro __using__(opts) do
-  #   case opts do
-  #     [] ->
-  #       quote do
-  #         import Rewire.Hello
-  #       end
-
-  #     _ ->
-  #       quote do
-  #         import Rewire.Hello, only: [hello: 0]
-  #       end
+  # defmacro __using__(_opts) do
+  #   quote do
+  #     import Rewire.Hello
+  #     import Rewire.Goodbye
   #   end
   # end
+
+  defmacro __using__(opts) do
+    case opts do
+      [] ->
+        quote do
+          import Rewire.Hello
+        end
+
+      _ ->
+        quote do
+          import Rewire.Hello, only: [hello: 0]
+        end
+    end
+  end
 end

--- a/fixtures/macro.ex
+++ b/fixtures/macro.ex
@@ -1,21 +1,14 @@
 defmodule Rewire.Macro do
-  # defmacro __using__(_opts) do
-  #   quote do
-  #     import Rewire.Hello
-  #     import Rewire.Goodbye
-  #   end
-  # end
-
   defmacro __using__(opts) do
     case opts do
-      [] ->
+      [use_alias: true] ->
         quote do
-          import Rewire.Hello
+          alias Rewire.Hello
         end
 
       _ ->
         quote do
-          import Rewire.Hello, only: [hello: 0]
+          import Rewire.Hello
         end
     end
   end

--- a/fixtures/module_with_macro.ex
+++ b/fixtures/module_with_macro.ex
@@ -1,0 +1,9 @@
+defmodule Rewire.ModuleWithMacro do
+  use Rewire.Macro
+  # require Rewire.Macro
+  # Rewire.Macro.__using__([])
+
+  def hello_passthrough do
+    hello()
+  end
+end

--- a/fixtures/module_with_macro.ex
+++ b/fixtures/module_with_macro.ex
@@ -4,4 +4,8 @@ defmodule Rewire.ModuleWithMacro do
   def hello_passthrough do
     hello()
   end
+
+  def good_afternoon_passthrough do
+    good_afternoon()
+  end
 end

--- a/fixtures/module_with_macro.ex
+++ b/fixtures/module_with_macro.ex
@@ -1,7 +1,5 @@
 defmodule Rewire.ModuleWithMacro do
   use Rewire.Macro
-  # require Rewire.Macro
-  # Rewire.Macro.__using__([])
 
   def hello_passthrough do
     hello()

--- a/fixtures/module_with_macro_with_args.ex
+++ b/fixtures/module_with_macro_with_args.ex
@@ -4,4 +4,8 @@ defmodule Rewire.ModuleWithMacroWithArgs do
   def hello_passthrough do
     Hello.hello()
   end
+
+  def good_afternoon_passthrough do
+    Macro.good_afternoon()
+  end
 end

--- a/fixtures/module_with_macro_with_args.ex
+++ b/fixtures/module_with_macro_with_args.ex
@@ -1,0 +1,7 @@
+defmodule Rewire.ModuleWithMacroWithArgs do
+  use Rewire.Macro, arg1: :value1
+
+  def hello_passthrough do
+    hello()
+  end
+end

--- a/fixtures/module_with_macro_with_args.ex
+++ b/fixtures/module_with_macro_with_args.ex
@@ -1,7 +1,7 @@
 defmodule Rewire.ModuleWithMacroWithArgs do
-  use Rewire.Macro, arg1: :value1
+  use Rewire.Macro, use_alias: true
 
   def hello_passthrough do
-    hello()
+    Hello.hello()
   end
 end

--- a/lib/rewire/cover.ex
+++ b/lib/rewire/cover.ex
@@ -71,7 +71,7 @@ defmodule Rewire.Cover do
     {_, binary, _} = :code.get_object_code(:cover)
     {:ok, {_, [{_, {_, abstract_code}}]}} = :beam_lib.chunks(binary, [:abstract_code])
     {:ok, module, binary} = :compile.forms(abstract_code, [:export_all])
-    :code.load_binary(module, '', binary)
+    :code.load_binary(module, ~c"", binary)
   end
 
   defp replace_coverdata!(rewired, original_module) do

--- a/lib/rewire/module.ex
+++ b/lib/rewire/module.ex
@@ -146,7 +146,7 @@ defmodule Rewire.Module do
   defp rewrite(use_ast = {:use, _l1, [{:__aliases__, _l2, _macro_ast} | _args]}, acc) do
     {:__block__, [], [{:__block__, [], [req, using]}]} = Macro.expand(use_ast, __ENV__)
     {:require, _counter_ctx, [required_module]} = req
-    {:ok, env} = Macro.Env.define_require(__ENV__, [], required_module)
+    env = %{__ENV__ | requires: [required_module] ++ __ENV__.requires}
 
     {Macro.expand(using, env), acc}
   end

--- a/lib/rewire/module.ex
+++ b/lib/rewire/module.ex
@@ -143,6 +143,13 @@ defmodule Rewire.Module do
     )
   end
 
+  defp rewrite(use_ast = {:use, l1, [{:__aliases__, _l2, _macro_ast} | _args]}, acc) do
+    {:ok, env} = Macro.Env.define_require(__ENV__, [], Rewire.Macro)
+    {:__block__, [], [{:__block__, [], [_req, using_call]}]} = Macro.expand(use_ast, env)
+
+    {Macro.expand(using_call, env), acc}
+  end
+
   # Removes a single alias (ie `alias A.A`) pointing to an overriden module dependency. Keeps the others.
   defp rewrite(
          expr = {:alias, _, [{:__aliases__, _, module_ast}]},

--- a/lib/rewire/module.ex
+++ b/lib/rewire/module.ex
@@ -143,11 +143,12 @@ defmodule Rewire.Module do
     )
   end
 
-  defp rewrite(use_ast = {:use, l1, [{:__aliases__, _l2, _macro_ast} | _args]}, acc) do
-    {:ok, env} = Macro.Env.define_require(__ENV__, [], Rewire.Macro)
-    {:__block__, [], [{:__block__, [], [_req, using_call]}]} = Macro.expand(use_ast, env)
+  defp rewrite(use_ast = {:use, _l1, [{:__aliases__, _l2, _macro_ast} | _args]}, acc) do
+    {:__block__, [], [{:__block__, [], [req, using]}]} = Macro.expand(use_ast, __ENV__)
+    {:require, _counter_ctx, [required_module]} = req
+    {:ok, env} = Macro.Env.define_require(__ENV__, [], required_module)
 
-    {Macro.expand(using_call, env), acc}
+    {Macro.expand(using, env), acc}
   end
 
   # Removes a single alias (ie `alias A.A`) pointing to an overriden module dependency. Keeps the others.

--- a/test/rewire_alias_test.exs
+++ b/test/rewire_alias_test.exs
@@ -3,44 +3,44 @@ defmodule RewireAliasTest do
   import Rewire
 
   describe "rewire as alias" do
-    # test "and use shorthand name" do
-    #   rewire Rewire.ModuleWithDependency, Hello: Bonjour, debug: true
-    #   assert ModuleWithDependency.hello() == "bonjour"
-    # end
+    test "and use shorthand name" do
+      rewire Rewire.ModuleWithDependency, Hello: Bonjour
+      assert ModuleWithDependency.hello() == "bonjour"
+    end
 
-    # test "and use renamed alias" do
-    #   rewire Rewire.ModuleWithDependency, Hello: Bonjour, as: RewiredModule, debug: true
-    #   assert RewiredModule.hello() == "bonjour"
-    # end
+    test "and use renamed alias" do
+      rewire Rewire.ModuleWithDependency, Hello: Bonjour, as: RewiredModule
+      assert RewiredModule.hello() == "bonjour"
+    end
 
-    # test "multiple ones" do
-    #   rewire Rewire.ModuleWithNested.Nested.NestedNested, Hello: Bonjour
-    #   rewire Rewire.ModuleWithNested.Nested, NestedNested: NestedNested
-    #   rewire Rewire.ModuleWithNested, Nested: Nested
+    test "multiple ones" do
+      rewire Rewire.ModuleWithNested.Nested.NestedNested, Hello: Bonjour
+      rewire Rewire.ModuleWithNested.Nested, NestedNested: NestedNested
+      rewire Rewire.ModuleWithNested, Nested: Nested
 
-    #   assert ModuleWithNested.hello() == "bonjour"
-    # end
+      assert ModuleWithNested.hello() == "bonjour"
+    end
 
-    # test "however, the original module will stay the same" do
-    #   rewire Rewire.ModuleWithDependency, Hello: Bonjour
-    #   assert Rewire.ModuleWithDependency.hello() == "hello"
-    # end
+    test "however, the original module will stay the same" do
+      rewire Rewire.ModuleWithDependency, Hello: Bonjour
+      assert Rewire.ModuleWithDependency.hello() == "hello"
+    end
 
-    # test "works together with a block" do
-    #   rewire Rewire.ModuleWithDependency, Hello: Bonjour
+    test "works together with a block" do
+      rewire Rewire.ModuleWithDependency, Hello: Bonjour
 
-    #   rewire ModuleWithDependency, Goodbye: AuRevoir do
-    #     assert ModuleWithDependency.hello() == "bonjour"
-    #     assert ModuleWithDependency.bye() == "au revoir"
-    #   end
-    # end
+      rewire ModuleWithDependency, Goodbye: AuRevoir do
+        assert ModuleWithDependency.hello() == "bonjour"
+        assert ModuleWithDependency.bye() == "au revoir"
+      end
+    end
 
     test "works for macro" do
-      rewire Rewire.ModuleWithMacro, Hello: Bonjour, debug: true
+      rewire Rewire.ModuleWithMacro, Hello: Bonjour
       assert ModuleWithMacro.hello_passthrough() == "bonjour"
 
-      # rewire Rewire.ModuleWithMacroWithArgs, Hello: Bonjour, debug: true
-      # assert ModuleWithMacroWithArgs.hello_passthrough() == "bonjour"
+      rewire Rewire.ModuleWithMacroWithArgs, Hello: Bonjour
+      assert ModuleWithMacroWithArgs.hello_passthrough() == "bonjour"
     end
   end
 end

--- a/test/rewire_alias_test.exs
+++ b/test/rewire_alias_test.exs
@@ -36,11 +36,13 @@ defmodule RewireAliasTest do
     end
 
     test "works for macro" do
-      rewire Rewire.ModuleWithMacro, Hello: Bonjour
+      rewire Rewire.ModuleWithMacro, Hello: Bonjour, Macro: BonApresMidi
       assert ModuleWithMacro.hello_passthrough() == "bonjour"
+      assert ModuleWithMacro.good_afternoon_passthrough() == "bon apres-midi"
 
-      rewire Rewire.ModuleWithMacroWithArgs, Hello: Bonjour
+      rewire Rewire.ModuleWithMacroWithArgs, Hello: Bonjour, Macro: BonApresMidi
       assert ModuleWithMacroWithArgs.hello_passthrough() == "bonjour"
+      assert ModuleWithMacroWithArgs.good_afternoon_passthrough() == "bon apres-midi"
     end
   end
 end

--- a/test/rewire_alias_test.exs
+++ b/test/rewire_alias_test.exs
@@ -3,36 +3,44 @@ defmodule RewireAliasTest do
   import Rewire
 
   describe "rewire as alias" do
-    test "and use shorthand name" do
-      rewire Rewire.ModuleWithDependency, Hello: Bonjour
-      assert ModuleWithDependency.hello() == "bonjour"
-    end
+    # test "and use shorthand name" do
+    #   rewire Rewire.ModuleWithDependency, Hello: Bonjour, debug: true
+    #   assert ModuleWithDependency.hello() == "bonjour"
+    # end
 
-    test "and use renamed alias" do
-      rewire Rewire.ModuleWithDependency, Hello: Bonjour, as: RewiredModule
-      assert RewiredModule.hello() == "bonjour"
-    end
+    # test "and use renamed alias" do
+    #   rewire Rewire.ModuleWithDependency, Hello: Bonjour, as: RewiredModule, debug: true
+    #   assert RewiredModule.hello() == "bonjour"
+    # end
 
-    test "multiple ones" do
-      rewire Rewire.ModuleWithNested.Nested.NestedNested, Hello: Bonjour
-      rewire Rewire.ModuleWithNested.Nested, NestedNested: NestedNested
-      rewire Rewire.ModuleWithNested, Nested: Nested
+    # test "multiple ones" do
+    #   rewire Rewire.ModuleWithNested.Nested.NestedNested, Hello: Bonjour
+    #   rewire Rewire.ModuleWithNested.Nested, NestedNested: NestedNested
+    #   rewire Rewire.ModuleWithNested, Nested: Nested
 
-      assert ModuleWithNested.hello() == "bonjour"
-    end
+    #   assert ModuleWithNested.hello() == "bonjour"
+    # end
 
-    test "however, the original module will stay the same" do
-      rewire Rewire.ModuleWithDependency, Hello: Bonjour
-      assert Rewire.ModuleWithDependency.hello() == "hello"
-    end
+    # test "however, the original module will stay the same" do
+    #   rewire Rewire.ModuleWithDependency, Hello: Bonjour
+    #   assert Rewire.ModuleWithDependency.hello() == "hello"
+    # end
 
-    test "works together with a block" do
-      rewire Rewire.ModuleWithDependency, Hello: Bonjour
+    # test "works together with a block" do
+    #   rewire Rewire.ModuleWithDependency, Hello: Bonjour
 
-      rewire ModuleWithDependency, Goodbye: AuRevoir do
-        assert ModuleWithDependency.hello() == "bonjour"
-        assert ModuleWithDependency.bye() == "au revoir"
-      end
+    #   rewire ModuleWithDependency, Goodbye: AuRevoir do
+    #     assert ModuleWithDependency.hello() == "bonjour"
+    #     assert ModuleWithDependency.bye() == "au revoir"
+    #   end
+    # end
+
+    test "works for macro" do
+      rewire Rewire.ModuleWithMacro, Hello: Bonjour, debug: true
+      assert ModuleWithMacro.hello_passthrough() == "bonjour"
+
+      # rewire Rewire.ModuleWithMacroWithArgs, Hello: Bonjour, debug: true
+      # assert ModuleWithMacroWithArgs.hello_passthrough() == "bonjour"
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,6 +8,10 @@ defmodule AuRevoir do
   def bye(), do: "au revoir"
 end
 
+defmodule BonApresMidi do
+  def good_afternoon(), do: "bon apres-midi"
+end
+
 Mox.defmock(HelloMock, for: Rewire.Hello)
 
 defmodule TestHelpers do


### PR DESCRIPTION
Resolves #20, invalidates #21.

This PR adds support for rewiring aliases/imports that come through the `use` macro. I started looking into this yesterday without luck but, by pure coincidence, Elixir 1.17.0 released today and introduced the `Macro.Env.define_require` function which seemed like it might solve this issue!

Once I confirmed that I could use that new function, I looked into backporting its functionality and it turns out it was really quite easy 🙌 

NOTE: I've only actually tested on Elixir 1.16 and 1.17 (released today).